### PR TITLE
Minor cleanups

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -11,5 +11,5 @@ Interact 0.3.5
 Interpolations 0.3.6
 LightXML 0.4.0
 MeshIO 0.0.6
-RigidBodyDynamics 0.0.2
+RigidBodyDynamics 0.0.3
 StaticArrays 0.0.4

--- a/src/RigidBodyTreeInspector.jl
+++ b/src/RigidBodyTreeInspector.jl
@@ -1,4 +1,4 @@
-# __precompile__()  # precompilation blocked by https://github.com/JuliaGeometry/Quaternions.jl/issues/18 via RigidBodyDynamics
+__precompile__()
 
 module RigidBodyTreeInspector
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ end
     state = MechanismState(Float64, mechanism)
     zero!(state)
     draw(vis, state)
-    times, states = simulate(state, [0, 1]);
+    times, states = simulate(state, 1);
     animate(vis, mechanism, times, states)
 end
 


### PR DESCRIPTION
Changes all GeometryData() instances to have IdentityTransformation() as their internal transform, since we can rely on RBD frames to provide all transforms for the visualizer now. 